### PR TITLE
Incorrect bitwise calculation in HighloadWalletV3QueryIdSequence.restore due to non-power-of-two bit size (1023 bits)

### DIFF
--- a/packages/highload-wallet-v3/src/highload-wallet-v3-query-id-sequence.ts
+++ b/packages/highload-wallet-v3/src/highload-wallet-v3-query-id-sequence.ts
@@ -49,12 +49,11 @@ export class HighloadWalletV3QueryIdSequence {
     );
   }
 
-  static restore(queryId: number): HighloadWalletV3QueryIdSequence {
-    const shift = queryId >> HighloadWalletV3QueryIdSequence.BIT_NUMBER_SIZE;
-    const bitNumber = queryId & HighloadWalletV3QueryIdSequence.BIT_NUMBER_MASK;
-
+  static restore(queryId: number) {
+    const shift = (queryId / BIT_NUMBER_MASK) | 0; // const shift = Math.floor(queryId / 1023)
+    const bitNumber = queryId - shift * BIT_NUMBER_MASK; // const bitNumber = queryId % 1023
     return new HighloadWalletV3QueryIdSequence(shift, bitNumber);
-  }
+}
 
   current() {
     return (this.shift << HighloadWalletV3QueryIdSequence.BIT_NUMBER_SIZE) | this.bitNumber;


### PR DESCRIPTION
### Description:

The method HighloadWalletV3QueryIdSequence.restore(queryId) currently calculates shift and bitNumber incorrectly because it relies on bitwise operations suitable only for power-of-two bit sizes (e.g., 1024 bits). However, the TON blockchain explicitly uses cells of size **1023 bits**, which is not a power of two.

The existing implementation:

```javascript
const shift = queryId >> HighloadWalletV3QueryIdSequence.BIT_NUMBER_SIZE;
const bitNumber = queryId & HighloadWalletV3QueryIdSequence.BIT_NUMBER_MASK;
```

produces incorrect results. For instance:

```javascript
// Expected: shift=1, bitNumber=0
// Actual incorrect result: shift=0, bitNumber=1023
HighloadWalletV3QueryIdSequence.restore(1023);
```


-------

### Root Cause:

Bitwise operations (>>, &) assume a power-of-two cell size (1024 bits), but TON cells have a size of exactly 1023 bits, making these operations invalid.

-------

### Recommended Fix:

Replace the bitwise calculations with arithmetic calculations explicitly tailored for 1023-bit cells:


```typescript
private restoreQueryId(queryId: number): HighloadWalletV3QueryIdSequence {
  const BIT_NUMBER_SIZE = 10;
  const BIT_NUMBER_MASK = (1 << BIT_NUMBER_SIZE) - 1; // 1023
  const shift = queryId >> BIT_NUMBER_SIZE;
  const bitNumber = queryId & BIT_NUMBER_MASK;
  return new HighloadWalletV3QueryIdSequence(shift, bitNumber);
}
```



-------

### Recommended Actions:
-  Apply the fix above to the specified file:

```
packages/highload-wallet-v3/src/highload-wallet-v3-query-id-sequence.ts
```

- Update comments and constants to explicitly state the correct 1023-bit size.
